### PR TITLE
FEAT: About page

### DIFF
--- a/server/autoeq_srv/routes/const.py
+++ b/server/autoeq_srv/routes/const.py
@@ -22,18 +22,38 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""AutoEQ Headphone app pages."""
+"""Code for the headphone data model."""
+import os
+from flask import current_app
 
-from flask import render_template, current_app
+# Root directory for measurement/result data, currently the GitHub checkout root
+AEQ_ROOT = aeq_root = current_app.config['AEQ_ROOT']
 
-from .api import ORATORY_RESULTS
+# Measurement types
+ORTRY = 'oratory1990'
 
-@current_app.route("/")
-def home():
-    """Application home page."""
-    return render_template('headphones.html', headphones=ORATORY_RESULTS)
+# Root dir for measurments, manufacturers, and type sub-dirs
+MEAS_ROOT = os.path.join(AEQ_ROOT, 'measurements')
+ORTRY_MEAS_ROOT = os.path.join(MEAS_ROOT, ORTRY)
+MNFCT_FILE_NAME = 'manufacturers.tsv'
+MNFCT_FILE = os.path.join(MEAS_ROOT, 'manufacturers.tsv')
 
-@current_app.route("/about/")
-def about():
-    """Application about page."""
-    return render_template('about.html')
+# Target types
+HRMN_INEAR_2019V2 = 'harman_in-ear_2019v2'
+HRMN_OVEAR_2018 = 'harman_over-ear_2018'
+
+# Phone types
+IN_EAR = 'inear'
+OVER_EAR = 'overear'
+
+# Results
+RES_ROOT = os.path.join(AEQ_ROOT, 'results')
+NAME_FILE_NAME = 'name_index.tsv'
+ORTRY_RES_ROOT = os.path.join(RES_ROOT, ORTRY)
+ORTRY_NAMES = os.path.join(ORTRY_MEAS_ROOT, NAME_FILE_NAME)
+ORTRY_INEAR_RES_ROOT = os.path.join(ORTRY_RES_ROOT, HRMN_INEAR_2019V2)
+ORTRY_OVEAR_RES_ROOT = os.path.join(ORTRY_RES_ROOT, HRMN_OVEAR_2018)
+ORTRY_RES_BY_TYPE = {
+    IN_EAR: ORTRY_INEAR_RES_ROOT,
+    OVER_EAR: ORTRY_OVEAR_RES_ROOT
+}

--- a/server/autoeq_srv/templates/about.html
+++ b/server/autoeq_srv/templates/about.html
@@ -1,0 +1,29 @@
+{% extends "page.html" %}
+{% block title %}About{% endblock %}
+{% block page_content %}
+  <h1>About this site</h1>
+  <p class="lead">Convenient access to headphone convolution filters.</p>
+  <p>
+    A quick overview of what the site's for and who's work we're using. Someday
+    this should be more informative but there's more fun stuff to be working on
+    right now.
+  </p>
+  <h2>AutoEq</h2>
+  <p>
+    This is a Python/Flask site that presents a more user friendly view of the
+    great work done by <a alt="Jaakko Pasanen's GitHub page." href="https://github.com/jaakkopasanen">Jaakko Pasanen</a>
+    on the <a alt="The AutoEq GitHub project." href="https://github.com/jaakkopasanen/AutoEq">AutoEq project</a>.
+  </p>
+  <h2>Bootstrap</h2>
+  <p>
+    The site uses <a href="https://getbootstrap.com/docs/4.0/getting-started/introduction/" alt="Bootstrap home page.">Bootstrap</a>
+    for web page layout and features, mainly because I'm comfortable with it.
+  </p>
+  <h2>Icons and Type Badges</h2>
+  <p>
+    The site uses icons from the <a alt="The Noun project home page." href="https://thenounproject.com/">Noun project</a>,
+    an online collection of icons. The site also uses some elements from the
+    <a alt="Font Awesome home page" href="https://fontawesome.com/">Font Awesome</a>
+    icon library.
+  </p>
+{% endblock page_content %}

--- a/server/autoeq_srv/templates/headphones.html
+++ b/server/autoeq_srv/templates/headphones.html
@@ -2,7 +2,14 @@
 {% block title %}Find my headphones{% endblock %}
 {% block page_content %}
   <h1>The Big List of Headphones</h1>
-  <p class="lead">We've currently got {{ headphones|length }} headphones listed, use search and sort to find yours.</p>
+  <p class="lead">
+    We've currently got {{ headphones|length }} headphones listed, use search and sort to find yours.
+  </p>
+  <p>
+    Once you've found your headphones to download a zip archive containing a
+    pair of convolution filters (WAV files). These correct your headphones to an
+    appropriate Harman target. They should sound better using them.
+  </p>
   <table  class="table table-striped" data-toggle="table" data-search="true">
     <thead class="thead-dark">
       <tr>

--- a/server/autoeq_srv/templates/navbar.html
+++ b/server/autoeq_srv/templates/navbar.html
@@ -1,0 +1,14 @@
+  <!-- Fixed navbar -->
+  <nav class="navbar navbar-expand-md navbar-dark bg-dark mb-4">
+    <a class="navbar-brand" href="/">Headphones</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarCollapse">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="/about/">About</a>
+        </li>
+      </ul>
+    </div>
+</nav>

--- a/server/autoeq_srv/templates/page.html
+++ b/server/autoeq_srv/templates/page.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Page{% endblock %}
 {% block page_header %}
+{% include "navbar.html" %}
 {% endblock %}
 {% block page_layout %}
   <div class="container" role="main">


### PR DESCRIPTION
- added a top level menu since we now have 2 pages;
- added an about page with some basic attribution;
- tidied up the code that retrieves Oratory results; and
- minor refactoring:
  - refactored server app's `route` constant values to its own file; and
  - removed hard-coded string repetition.