### PR TITLE
FEAT: Recommended headphone list

### DIFF
--- a/server/autoeq_srv/routes/api.py
+++ b/server/autoeq_srv/routes/api.py
@@ -25,26 +25,26 @@
 """AutoEQ Web REST API."""
 from flask import jsonify, current_app, send_from_directory
 
-from .model import (get_manufacturers, get_oratory_phones, get_oratory_results,
-    get_oratory_filters)
+from .model import (
+    get_filters,
+    MANUFACTURERS,
+    RESULTS
+)
 
 APP = current_app
-MANUFACTURERS = get_manufacturers()
-ORATORY_PHONES = get_oratory_phones()
-ORATORY_RESULTS = get_oratory_results()
 
 @APP.route("/api/manufacturers/")
 def manufacturers():
     """Get a complete list of headphone manufacturers."""
     return jsonify(manufacturers=MANUFACTURERS)
 
-@APP.route("/api/phones/")
-def phones():
-    """Get a complete list of headphones."""
-    return jsonify(ORATORY_PHONES)
+@APP.route("/api/results/<source>")
+def results(source):
+    """Get a complete list of results by source."""
+    return jsonify(results=RESULTS[source])
 
-@APP.route("/api/filters/<phone_type>/<name>")
-def results(phone_type, name):
+@APP.route("/api/filters/<source>/<target>/<model>")
+def filters(source, target, model):
     """Get a complete list of headphones."""
-    send_dir, zip_name = get_oratory_filters(phone_type, name)
+    send_dir, zip_name = get_filters(source, target, model)
     return send_from_directory(send_dir, zip_name)

--- a/server/autoeq_srv/routes/const.py
+++ b/server/autoeq_srv/routes/const.py
@@ -30,32 +30,64 @@ from flask import current_app
 AEQ_ROOT = aeq_root = current_app.config['AEQ_ROOT']
 
 # Measurement types
-ORTRY = 'oratory1990'
+README = 'README.md'
 
 # Root dir for measurments, manufacturers, and type sub-dirs
 MEAS_ROOT = os.path.join(AEQ_ROOT, 'measurements')
-ORTRY_MEAS_ROOT = os.path.join(MEAS_ROOT, ORTRY)
+
 MNFCT_FILE_NAME = 'manufacturers.tsv'
+NAME_FILE_NAME = 'name_index.tsv'
 MNFCT_FILE = os.path.join(MEAS_ROOT, 'manufacturers.tsv')
 
-# Target types
+# Targets
 HRMN_INEAR_2019V2 = 'harman_in-ear_2019v2'
 HRMN_OVEAR_2018 = 'harman_over-ear_2018'
 
-# Phone types
-IN_EAR = 'inear'
-OVER_EAR = 'overear'
+# Target types
+IN_EAR = 'in-ear'
+OVER_EAR = 'over-ear'
 
 # Results
 RES_ROOT = os.path.join(AEQ_ROOT, 'results')
-NAME_FILE_NAME = 'name_index.tsv'
-ORTRY_RES_ROOT = os.path.join(RES_ROOT, ORTRY)
-ORTRY_NAMES = os.path.join(ORTRY_MEAS_ROOT, NAME_FILE_NAME)
-ORTRY_INEAR_RES_ROOT = os.path.join(ORTRY_RES_ROOT, HRMN_INEAR_2019V2)
-ORTRY_OVEAR_RES_ROOT = os.path.join(ORTRY_RES_ROOT, HRMN_OVEAR_2018)
-ORTRY_RES_BY_TYPE = {
-    IN_EAR: ORTRY_INEAR_RES_ROOT,
-    OVER_EAR: ORTRY_OVEAR_RES_ROOT
+REC_RESULTS = os.path.join(RES_ROOT, README)
+ALL_RESULTS = os.path.join(RES_ROOT, 'INDEX.md')
+
+
+REC_SRC = {
+    'name': 'Recommended',
+    'title': 'Recommended results.',
+    'description': """
+    The recommended filters for your headphonesRecommendation priority is:
+    oratory1990 > Crinacle > Innerfidelity > Rtings > Headphone.com > Reference Audio Analyzer.
+    This means if there are measurements from multiple sources for the same headphone
+    model only the highest priority result will be shown in this list."""
+}
+
+SOURCES = {
+    'oratory1990': {
+        'name': 'Oratory',
+        'title': 'All Oratory results.',
+    },
+    'crinacle': {
+        'name': 'Crinacle',
+        'title': 'All Crinacle results.'
+    },
+    'innerfidelity': {
+        'name': 'Inner Fidelity',
+        'title': 'All Inner Fidelity results.'
+    },
+    'rtings': {
+        'name': 'Rtings',
+        'title': 'All Rtings results.'
+    },
+    'headphonecom': {
+        'name': 'Headphones.com',
+        'title': 'All Headphones.com results.'
+    },
+    'referenceaudioanalyzer': {
+        'name': 'RAA',
+        'title': 'All Reference Audio Analyzer results.'
+    }
 }
 
 PHONE_TYPE_DETAILS = {

--- a/server/autoeq_srv/routes/model.py
+++ b/server/autoeq_srv/routes/model.py
@@ -24,6 +24,7 @@
 # SOFTWARE.
 """Code for the headphone data model."""
 import os
+import re
 from zipfile import ZipFile
 from urllib.parse import unquote
 
@@ -31,13 +32,18 @@ from flask import current_app
 
 from autoeq_srv.routes.const import (
     MNFCT_FILE,
-    ORTRY_NAMES,
-    ORTRY_RES_BY_TYPE,
     OVER_EAR, IN_EAR,
-    PHONE_TYPE_DETAILS
+    PHONE_TYPE_DETAILS,
+    README,
+    REC_RESULTS,
+    RES_ROOT,
+    SOURCES
 )
 
 APP = current_app
+
+def _get_phone_type(to_parse):
+    return IN_EAR if IN_EAR in to_parse else OVER_EAR
 
 def _manufacturers_with_variants():
     """Return the raw manufacturers data including variants."""
@@ -56,6 +62,8 @@ def get_manufacturers():
         manufacturers.append(manufacturer[0])
     return manufacturers
 
+MANUFACTURERS = get_manufacturers()
+
 def resolve_manufacturer(name):
     """Return a canonical name and variant tuple."""
     for manufacturer in RAW_MANUFACTURERS:
@@ -63,26 +71,79 @@ def resolve_manufacturer(name):
             return manufacturer[0], name
     return None
 
-def get_oratory_phones():
-    """Return the list of headphones with Oratory measurements."""
-    phones = []
-    with open(ORTRY_NAMES,
-              encoding='utf-8') as _fh:
-        raw_names = _fh.read().strip().split('\n')
-        phone_parts = [m.strip().split('\t') for m in raw_names]
-    for phone in phone_parts:
-        if phone[0] == 'false_name':
-            continue
-        phones.append({ 'key': phone[1], 'name': phone[0], 'type': phone[2] })
-    return phones
+# def get_oratory_phones():
+#     """Return the list of headphones with Oratory measurements."""
+#     phones = []
+#     with open(ORTRY_NAMES, 'r',
+#               encoding='utf-8') as _fh:
+#         raw_names = _fh.read().strip().split('\n')
+#         phone_parts = [m.strip().split('\t') for m in raw_names]
+#     for phone in phone_parts:
+#         if phone[0] == 'false_name':
+#             continue
+#         phones.append({ 'key': phone[1], 'name': phone[0], 'type': phone[2] })
+#     return phones
 
-def get_oratory_results():
-    """Return the list of headphones with Oratory results."""
-    phones = []
-    for phone_type in [IN_EAR, OVER_EAR]:
-        phones.extend(get_phone_results(ORTRY_RES_BY_TYPE[phone_type],
-                                        phone_type))
-    return phones
+# ORATORY_PHONES = get_oratory_phones()
+
+def get_results_map():
+    """Return all results."""
+    results = {}
+    for source in SOURCES:
+        results[source] = parse_results_file(source,
+                                             os.path.join(RES_ROOT, source, README))
+    return results
+
+def parse_results_file(source, results_file):
+    """Return the list of recommended headphone results parsed from the README.md"""
+    results = []
+    # Open the results file
+    with open(results_file, 'r',
+              encoding='utf-8') as _fh:
+        # Split it on the newlines
+        raw_recs = _fh.read().strip().split('\n')
+        # For each line
+        for raw_rec in raw_recs:
+            # Regex to get the name, target and model path
+            tup_srch = re.search(r'- \[(.*)\]\(.\/(.*)\/(.*)\)', raw_rec)
+            # If we get a match
+            if tup_srch:
+                phone_type = _get_phone_type(tup_srch.group(2))
+                results.append({
+                    'source': source,
+                    'name': tup_srch.group(1),
+                    'type': PHONE_TYPE_DETAILS[phone_type],
+                    'target': tup_srch.group(2),
+                    'model' : tup_srch.group(3)
+                })
+    return results
+
+RESULTS = get_results_map()
+
+def get_results(source):
+    """Return all of the results for the supplied source."""
+    return RESULTS[source]
+
+def get_recommended_results():
+    """Return the list of recommended headphone results parsed from the README.md"""
+    recommendations = []
+    with open(REC_RESULTS, 'r',
+              encoding='utf-8') as _fh:
+        raw_recs = _fh.read().strip().split('\n')
+        for raw_rec in raw_recs:
+            tup_srch = re.search(r'- \[(.*)\]\(.\/(.*)\/(.*)\/(.*)\)', raw_rec)
+            if tup_srch:
+                phone_type = _get_phone_type(tup_srch.group(3))
+                recommendations.append({
+                    'source': tup_srch.group(2),
+                    'name': tup_srch.group(1),
+                    'type': PHONE_TYPE_DETAILS[phone_type],
+                    'target' : tup_srch.group(3),
+                    'model' : tup_srch.group(4)
+                })
+    return recommendations
+
+RECOMMENDED = get_recommended_results()
 
 def get_phone_results(to_scan, phone_type):
     """Return a list of phone directories."""
@@ -95,19 +156,22 @@ def get_phone_results(to_scan, phone_type):
                 })
     return phones
 
-def get_oratory_filters(phone_type, name):
-    """Return the zipped convolution filters for oratory results."""
-    phone_name = unquote(name)
-    phone_path = os.path.join(ORTRY_RES_BY_TYPE[phone_type],
-                              phone_name)
+def get_filters(source, target, model):
+    """Return the zipped convolution filters for the specified measurement source,
+    target and headphone model."""
+    phone_model = unquote(model)
+    phone_path = os.path.join(RES_ROOT,
+                              source,
+                              target,
+                              phone_model)
     if not os.path.isdir(phone_path):
         return None
-    zip_name = '{}_harman_results.zip'.format(phone_name)
+    zip_name = '{}_{}_results.zip'.format(phone_model, target)
     zip_path = os.path.join(phone_path, zip_name)
     if not os.path.isfile(zip_path):
         with ZipFile(zip_path, 'w') as reszip:
-            filter_name =  '{} minimum phase 44100Hz.wav'.format(phone_name)
+            filter_name =  '{} minimum phase 44100Hz.wav'.format(phone_model)
             reszip.write(os.path.join(phone_path, filter_name), arcname=filter_name)
-            filter_name =  '{} minimum phase 48000Hz.wav'.format(phone_name)
+            filter_name =  '{} minimum phase 48000Hz.wav'.format(phone_model)
             reszip.write(os.path.join(phone_path, filter_name), arcname=filter_name)
     return phone_path, zip_name

--- a/server/autoeq_srv/routes/pages.py
+++ b/server/autoeq_srv/routes/pages.py
@@ -26,14 +26,25 @@
 import os
 from flask import render_template, current_app, send_from_directory
 
-from .api import ORATORY_RESULTS
+from .model import RECOMMENDED, RESULTS
+from .const import SOURCES, REC_SRC
 
 FAVICO_DIR = os.path.join(current_app.root_path, 'static', 'favicon')
+
+@current_app.context_processor
+def inject_stage_and_region():
+    """Inject a global for sources."""
+    return dict(sources=SOURCES)
 
 @current_app.route("/")
 def home():
     """Application home page."""
-    return render_template('headphones.html', headphones=ORATORY_RESULTS)
+    return render_template('results.html', source=REC_SRC, headphones=RECOMMENDED)
+
+@current_app.route("/results/<source>")
+def results_by_source(source):
+    """Recommended filter sets according to preferences."""
+    return render_template('results.html', source=SOURCES[source], headphones=RESULTS[source])
 
 @current_app.route("/about/")
 def about():

--- a/server/autoeq_srv/templates/navbar.html
+++ b/server/autoeq_srv/templates/navbar.html
@@ -7,10 +7,20 @@
     <div class="collapse navbar-collapse" id="navbarCollapse">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item">
-          <a class="nav-link" href="/">Headphones</a>
+          <a class="nav-link" title="Recommended results for all headphones analysed." href="/">Recommended</a>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" title="Result sources" href="/results" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Results
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            {%- for source, details in sources.items() -%}
+              <a class="dropdown-item" title="{{ details.title }}" href="/results/{{ source }}">{{ details.name }}</a>
+            {%- endfor -%}
+          </div>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('about') }}">About</a>
+          <a class="nav-link" title="About the AutoEQ site." href="{{ url_for('about') }}">About</a>
         </li>
       </ul>
     </div>

--- a/server/autoeq_srv/templates/results.html
+++ b/server/autoeq_srv/templates/results.html
@@ -1,14 +1,19 @@
 {% extends "page.html" %}
-{% block title %}Find my headphones{% endblock %}
+{% block title %}Results | {{ source.name }}{% endblock %}
 {% block page_content %}
-  <h1>The Big List of Headphones</h1>
+  <h1>{{ source.title }}</h1>
   <p class="lead">
-    We've currently got {{ headphones|length }} headphones listed, use search and sort to find yours.
+    There are {{ headphones|length }} headphones listed, use search and sort to find yours.
   </p>
+  {% if source.description is defined %}
+  <p>
+    {{ source.description }}
+  </p>
+  {% endif %}
   <p>
     Once you've found your headphones to download a zip archive containing a
     pair of convolution filters (WAV files). These correct your headphones to an
-    appropriate Harman target. They should sound better using them.
+    appropriate Harman target. They should sound better using them, but YMMV.
   </p>
   <table  class="table table-striped" data-toggle="table" data-search="true">
     <thead class="thead-dark">
@@ -34,6 +39,6 @@
     <tr>
       <td><img src="{{ url_for('static', filename='img/' + model.type.icon) }}" alt="{{ model.type.alt }} headphones."/></td>
       <td>{{ model.name }}</td>
-      <td><a href="/api/filters/{{ model.type.code }}/{{ model.name }}"><i class="fas fa-file-archive fa-2x"></i></a></td>
+      <td><a href="/api/filters/{{ model.source }}/{{ model.target }}/{{ model.name }}"><i class="fas fa-file-archive fa-2x"></i></a></td>
     </tr>
 {% endmacro %}


### PR DESCRIPTION
- landing page now lists all recommended results;
- added result pages for each source, e.g. Oratory, Crinacle, etc.;
- result harvesting now done by parsing the result `README.md`s;
- filters delivered by `source/target/model` identifier;
- some presentational niceties; and
- removed some of the unused junk.